### PR TITLE
Bump dependency versions and make compatible with react 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,17 +16,17 @@
     "classnames": "^2.1.2"
   },
   "devDependencies": {
-    "babel-eslint": "^4.1.3",
-    "eslint": "^1.6.0",
-    "eslint-plugin-react": "^3.5.1",
+    "babel-eslint": "^8.0.0",
+    "eslint": "^4.10.0",
+    "eslint-plugin-react": "^7.0.0",
     "gulp": "^3.9.0",
-    "react": "^0.14.8",
-    "react-dom": "^0.14.8",
-    "react-addons-transition-group": "^0.14.8",
-    "react-component-gulp-tasks": "^0.7.6"
+    "prop-types": "^15.6.0",
+    "react": "^16.0.0",
+    "react-component-gulp-tasks": "git+ssh://git@github.com:snags88/react-component-gulp-tasks.git",
+    "react-dom": "^16.0.0"
   },
   "peerDependencies": {
-    "react": "^0.14.0"
+    "react": "^0.14.0 || ^15.0.0 || ^16"
   },
   "browserify-shim": {
     "react": "global:React"

--- a/src/ReactImageGallery.js
+++ b/src/ReactImageGallery.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import ImageViewer from './ReactImageViewer';
 
 class ImageGallery extends Component {
@@ -105,22 +106,22 @@ class ImageGallery extends Component {
 }
 
 ImageGallery.propTypes = {
-  changeCompareMode: React.PropTypes.func.isRequired,
-  compareMode: React.PropTypes.bool.isRequired,
-  currentImages: React.PropTypes.array.isRequired,
-  decrementSelectedImage: React.PropTypes.func.isRequired,
-  displayNext: React.PropTypes.func.isRequired,
-  displayPrev: React.PropTypes.func.isRequired,
-  images: React.PropTypes.array.isRequired,
-  incrementSelectedImage: React.PropTypes.func.isRequired,
-  lightboxIsOpen: React.PropTypes.bool.isRequired,
-  lightboxOpen: React.PropTypes.func.isRequired,
-  onProgress: React.PropTypes.func.isRequired,
-  onRequest: React.PropTypes.func.isRequired,
+  changeCompareMode: PropTypes.func.isRequired,
+  compareMode: PropTypes.bool.isRequired,
+  currentImages: PropTypes.array.isRequired,
+  decrementSelectedImage: PropTypes.func.isRequired,
+  displayNext: PropTypes.func.isRequired,
+  displayPrev: PropTypes.func.isRequired,
+  images: PropTypes.array.isRequired,
+  incrementSelectedImage: PropTypes.func.isRequired,
+  lightboxIsOpen: PropTypes.bool.isRequired,
+  lightboxOpen: PropTypes.func.isRequired,
+  onProgress: PropTypes.func.isRequired,
+  onRequest: PropTypes.func.isRequired,
   patientId: PropTypes.number,
-  progressStatus: React.PropTypes.bool,
-  requestStatus: React.PropTypes.bool,
-  resetImages: React.PropTypes.func.isRequired,
+  progressStatus: PropTypes.bool,
+  requestStatus: PropTypes.bool,
+  resetImages: PropTypes.func.isRequired,
 };
 
 export default ImageGallery;

--- a/src/ReactImageViewer.js
+++ b/src/ReactImageViewer.js
@@ -145,7 +145,7 @@ class ImageViewer extends Component {
 
     return (
       <div className={classNames}>
-        <div className="image-viewer-bg" onClick={this.props.onClose}></div>
+        <div className="image-viewer-bg" onClick={this.props.onClose} />
         <div className="image-viewer-actions">
           {this.renderProgressButton()}
           {this.renderRequestButton()}

--- a/src/ReactImageViewer.js
+++ b/src/ReactImageViewer.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class ImageViewer extends Component {
   constructor() {


### PR DESCRIPTION
this closes #1 

- `react-component-gulp-tasks` had an old dependency that the maintainer hasn't merged for like a year so just forked it in my own repo and just made it a dependency here